### PR TITLE
feat: add no-verify-guard hook (closes git hook bypass gap)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,7 +1,8 @@
 {
   "PreToolUse": [
     {"matcher": "Write|Edit|MultiEdit", "file": "plan-gate.sh", "type": "managed"},
-    {"matcher": "Bash", "file": "bash-gate.sh", "type": "managed"}
+    {"matcher": "Bash", "file": "bash-gate.sh", "type": "managed"},
+    {"matcher": "Bash", "file": "no-verify-guard.sh", "type": "managed"}
   ],
   "PostToolUse": [
     {"matcher": "Write|Edit|MultiEdit", "file": "doc-reminder.sh", "type": "managed"},

--- a/hooks/no-verify-guard.sh
+++ b/hooks/no-verify-guard.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# no-verify-guard: PreToolUse hook
+# Blocks git commands that attempt to bypass hooks via skip flags
+# Prevents agents from circumventing gate enforcement
+#
+# Powered by block-no-verify@1.1.2
+# https://github.com/tupe12334/block-no-verify
+
+exec npx --yes block-no-verify@1.1.2


### PR DESCRIPTION
## Summary

Adds `no-verify-guard.sh` — a PreToolUse Bash hook powered by [`block-no-verify@1.1.2`](https://github.com/tupe12334/block-no-verify) that blocks git commands using hook-skip flags. Registered alongside `bash-gate.sh` in `hooks.json`.

## Problem

The README states: *"hook-based enforcement that cannot be bypassed."*

`bash-gate.sh` already checks git commit/push commands — but an agent can still circumvent all hook enforcement with a single flag that instructs git to skip hooks. This silently bypasses `completion-gate.sh`, `bash-audit.sh`, and any pre-commit hooks in the project's git configuration.

## Changes

- `hooks/no-verify-guard.sh` — new hook, 3 lines, delegates entirely to `block-no-verify@1.1.2`
- `hooks/hooks.json` — adds the hook entry under `PreToolUse → Bash`

## What `block-no-verify` detects

- The `--no-verify` flag on any git subcommand (`commit`, `push`, `merge`, etc.)
- The `-n` shorthand on `git commit`
- `core.hooksPath` overrides (e.g., `git -c core.hooksPath=/dev/null commit`)

## Test plan

- [ ] `git commit` (normal) — passes through
- [ ] `git commit` with hook-skip flag — blocked with clear message
- [ ] `git push` with hook-skip flag — blocked
- [ ] Non-git bash commands — unaffected

Closes #1
