### PR TITLE
fix: empty SESSION_ID로 인한 cross-session hijack 차단

### DIFF
--- a/hooks/bash-gate.sh
+++ b/hooks/bash-gate.sh
@@ -69,6 +69,13 @@ if echo "$CMD" | grep -qE '^\s*git\s+(commit|push)\b'; then
     exit 0
   fi
 
+  # defense-in-depth: 빈 SESSION_ID로는 task resolve 금지 (cross-session hijack 방지)
+  if [ -z "$SESSION_ID" ]; then
+    log_block "BG-NO-SESSION" "⛔ [bash-gate] session_id 없이 hook 호출 불가."
+    jq -n '{decision:"block", reason:"⛔ [bash-gate] session_id 없이 hook 호출 불가. 호출자가 SESSION_ID를 설정해야 합니다."}'
+    exit 0
+  fi
+
   # .active 탐색 (resolve-task.sh)
   SCRIPT_DIR_CS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   source "$SCRIPT_DIR_CS/lib/resolve-task.sh"
@@ -370,6 +377,13 @@ fi
 # 4.5. PRE-CHECK 제거됨
 # SPAWNED_COUNT(/tmp/ 파일 기반) 검증이 fragile하여 정상 Dev 에이전트도 차단하는 버그 수정.
 # Lead 차단은 team 모드 CHECK 6-DEV (NON_LEAD_COUNT) 에서 처리.
+
+# defense-in-depth: 빈 SESSION_ID로는 task resolve 금지 (cross-session hijack 방지)
+if [ -z "$SESSION_ID" ]; then
+  log_block "BG-NO-SESSION" "⛔ [bash-gate] session_id 없이 hook 호출 불가."
+  jq -n '{decision:"block", reason:"⛔ [bash-gate] session_id 없이 hook 호출 불가. 호출자가 SESSION_ID를 설정해야 합니다."}'
+  exit 0
+fi
 
 # 5. Gate 검증 (plan-gate.sh CHECK 2~7 동일)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/completion-gate.sh
+++ b/hooks/completion-gate.sh
@@ -10,6 +10,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/block-logger.sh"
 INPUT=$(cat)
 export SESSION_ID
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+# 빈 SESSION_ID면 owner 판정 없이 통과 (Stop hook은 차단 시 세션 wedge → exit 0)
+[ -z "$SESSION_ID" ] && exit 0
 
 # 승인된 sub-agent는 completion-gate 스킵 (부모 세션이 관리)
 APPROVED_FILE="/tmp/.ai-bouncer-approved-agents"

--- a/hooks/lib/resolve-task.sh
+++ b/hooks/lib/resolve-task.sh
@@ -4,7 +4,8 @@
 #
 # 사용법: 호출 전 SESSION_ID 환경변수 설정 (hook stdin에서 추출)
 # SESSION_ID가 있으면 해당 세션의 태스크만 매칭
-# SESSION_ID가 없으면 첫 번째 활성 태스크 사용 (하위 호환)
+# SESSION_ID 없이는 .active 매칭 안 함 (cross-session hijack 방지)
+# 호출자는 반드시 hook stdin에서 추출한 session_id를 SESSION_ID 환경변수로 설정해야 함
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 REPO_NAME=$(basename "$REPO_ROOT" 2>/dev/null)
@@ -87,12 +88,9 @@ _resolve_from_base() {
     local state_file="${base}/${task_folder}/state.json"
     [ -f "$state_file" ] || continue
 
-    # SESSION_ID가 없으면 첫 번째 활성 태스크 사용
+    # 빈 SESSION_ID는 매칭 skip (cross-session hijack 방지)
     if [ -z "$SESSION_ID" ]; then
-      TASK_NAME="$task_folder"
-      DOCS_BASE="$base"
-      IS_MY_TASK=true
-      return 0
+      continue   # 빈 SESSION_ID로는 어떤 .active도 자기 owner로 인정 안 함
     fi
 
     # SESSION_ID 매칭

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -37,6 +37,13 @@ fi
 # SPAWNED_COUNT(/tmp/ 파일 기반) 검증이 fragile하여 정상 Dev 에이전트도 차단하는 버그 수정.
 # Lead 제거에 따라 이 검증은 불필요.
 
+# defense-in-depth: 빈 SESSION_ID로는 task resolve 금지 (cross-session hijack 방지)
+if [ -z "$SESSION_ID" ]; then
+  log_block "PG-NO-SESSION" "⛔ [plan-gate] session_id 없이 hook 호출 불가."
+  jq -n '{decision:"block", reason:"⛔ [plan-gate] session_id 없이 hook 호출 불가. 호출자가 SESSION_ID를 설정해야 합니다."}'
+  exit 0
+fi
+
 # resolve_task_dir: 공유 라이브러리 사용
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/resolve-task.sh"

--- a/tests/test-bash-gate.sh
+++ b/tests/test-bash-gate.sh
@@ -30,14 +30,17 @@ cat > "$TMPDIR/.claude/ai-bouncer/config.json" <<'EOF'
 EOF
 
 TASK_DIR="$TMPDIR/.ai-bouncer-tasks/2026-01-01/test-task"
+OWNER_SID="bg-owner-sess"
 mkdir -p "$TASK_DIR/verifications"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 cat > "$TASK_DIR/state.json" <<'EOF'
 {"workflow_phase":"planning","plan_approved":false,"dev_phases":{}}
 EOF
 
 run_gate() {
   local cmd="$1" sid="${2:-}"
+  # sid 미지정/빈값이면 .active owner로 폴백 (빈 SESSION_ID hijack 방지 후 정상 매칭 유지)
+  [ -z "$sid" ] && sid=$(cat "$TASK_DIR/.active" 2>/dev/null | tr -d '[:space:]')
   (cd "$TMPDIR" && jq -n --arg cmd "$cmd" --arg sid "$sid" \
     '{"tool_name":"Bash","session_id":$sid,"tool_input":{"command":$cmd}}' \
     | bash "$HOOKS_DIR/bash-gate.sh" 2>/dev/null) || true
@@ -81,7 +84,7 @@ check "TC-05: development → cancelled (bash) → block" "$OUT" "block"
 # TC-06: rm .active + workflow_phase=development → block
 OUT=$(run_gate "rm -f .ai-bouncer-tasks/2026-01-01/test-task/.active" "")
 check "TC-06: rm .active + phase=development → block" "$OUT" "block"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 cat > "$TASK_DIR/state.json" <<'EOF'
 {"workflow_phase":"planning","plan_approved":false,"dev_phases":{}}
 EOF
@@ -303,7 +306,7 @@ cat > "$TASK_DIR/state.json" <<'EOF'
 EOF
 OUT=$(run_gate "rm -f .ai-bouncer-tasks/2026-01-01/test-task/.active" "")
 check "TC-50: rm .active + done → allow" "$OUT" "allow"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # TC-51: rm .active + cancelled 상태 → allow
 cat > "$TASK_DIR/state.json" <<'EOF'
@@ -311,7 +314,7 @@ cat > "$TASK_DIR/state.json" <<'EOF'
 EOF
 OUT=$(run_gate "rm -f .ai-bouncer-tasks/2026-01-01/test-task/.active" "")
 check "TC-51: rm .active + cancelled → allow" "$OUT" "allow"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # TC-52: rm .active + verification 상태 → block
 cat > "$TASK_DIR/state.json" <<'EOF'
@@ -319,7 +322,7 @@ cat > "$TASK_DIR/state.json" <<'EOF'
 EOF
 OUT=$(run_gate "rm -f .ai-bouncer-tasks/2026-01-01/test-task/.active" "")
 check "TC-52: rm .active + verification → block" "$OUT" "block"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # ── verifications/ 접근 제어 ──
 

--- a/tests/test-completion-gate.sh
+++ b/tests/test-completion-gate.sh
@@ -32,8 +32,9 @@ TMPDIR=$(mktemp -d)
 trap "rm -rf '$TMPDIR'" EXIT
 
 TASK_DIR="$TMPDIR/.ai-bouncer-tasks/2026-01-01/test-task"
+OWNER_SID="cg-owner-sess"
 mkdir -p "$TASK_DIR/verifications"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 write_state() {
   cat > "$TASK_DIR/state.json" <<EOF
@@ -42,7 +43,7 @@ EOF
 }
 
 run_gate() {
-  local sid="${1:-}"
+  local sid="${1:-$(cat "$TASK_DIR/.active" 2>/dev/null | tr -d '[:space:]')}"
   (cd "$TMPDIR" && echo "{\"session_id\":\"$sid\",\"stop_hook_active\":false}" | bash "$HOOKS_DIR/completion-gate.sh" 2>/dev/null) || true
 }
 
@@ -197,7 +198,7 @@ check "TC-22: 타 session_id → IS_MY_TASK=false → allow" \
   "$(run_gate "$OTHER_SID")" "allow"
 
 # .active 원상복구
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # ── subagent 우회 ──
 
@@ -328,7 +329,7 @@ run_gate "$ESC_SID" >/dev/null
 [ ! -f "$TASK_DIR/.cg-stop-count-$ESC_SID" ] && { echo "✅ TC-36: verification 전환 시 카운터 삭제"; PASS=$((PASS+1)); } || { echo "❌ TC-36: 카운터 파일 잔존"; FAIL=$((FAIL+1)); }
 
 # .active 원상복구
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 echo ""
 echo "결과: PASS=$PASS FAIL=$FAIL"

--- a/tests/test-e2e-workflow.sh
+++ b/tests/test-e2e-workflow.sh
@@ -46,11 +46,13 @@ cat > "$TMPDIR/.claude/ai-bouncer/config.json" <<'EOF'
 EOF
 
 TASK_DIR="$TMPDIR/.ai-bouncer-tasks/2026-01-01/e2e-test"
+OWNER_SID="e2e-owner-sess"
 mkdir -p "$TASK_DIR/verifications"
 
 # 헬퍼 함수
 run_plan() {
   local file="$1" sid="${2:-}" content="${3:-x}"
+  [ -z "$sid" ] && sid="$OWNER_SID"
   (cd "$TMPDIR" && jq -n --arg file "$file" --arg sid "$sid" --arg content "$content" \
     '{"tool_name":"Write","session_id":$sid,"tool_input":{"file_path":$file,"content":$content}}' \
     | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
@@ -58,6 +60,7 @@ run_plan() {
 
 run_bash() {
   local cmd="$1" sid="${2:-}"
+  [ -z "$sid" ] && sid="$OWNER_SID"
   (cd "$TMPDIR" && jq -n --arg cmd "$cmd" --arg sid "$sid" \
     '{"tool_name":"Bash","session_id":$sid,"tool_input":{"command":$cmd}}' \
     | bash "$HOOKS_DIR/bash-gate.sh" 2>/dev/null) || true
@@ -65,6 +68,7 @@ run_bash() {
 
 run_stop() {
   local sid="${1:-}"
+  [ -z "$sid" ] && sid="$OWNER_SID"
   (cd "$TMPDIR" && jq -n --arg sid "$sid" \
     '{"session_id":$sid}' \
     | bash "$HOOKS_DIR/completion-gate.sh" 2>/dev/null) || true
@@ -77,7 +81,7 @@ echo "=== SCENARIO A: Planning 단계 ==="
 cat > "$TASK_DIR/state.json" <<'EOF'
 {"workflow_phase":"planning","plan_approved":false,"dev_phases":{}}
 EOF
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # A-01: planning + 소스코드 수정 → block (plan 없음)
 OUT=$(run_plan "$TMPDIR/src/app.py" "")
@@ -366,7 +370,7 @@ check "H-02: no .active → bash gate allow" "$OUT" "allow"
 OUT=$(run_stop "")
 check_stop "H-03: no .active → stop continue" "$OUT" "continue"
 
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # ===== SCENARIO I: 전환 - state.json workflow_phase 갱신 =====
 echo ""
@@ -567,23 +571,24 @@ cat > "$TMPDIR2/.claude/ai-bouncer/config.json" <<'EOF'
 EOF
 
 TASK2="$TMPDIR2/.ai-bouncer-tasks/2026-01-01/full-flow"
+OWNER_SID2="e2e-owner-sess2"
 mkdir -p "$TASK2/verifications"
-touch "$TASK2/.active"
+echo "$OWNER_SID2" > "$TASK2/.active"
 
 run_plan2() {
   local file="$1"
-  (cd "$TMPDIR2" && jq -n --arg file "$file" \
-    '{"tool_name":"Write","session_id":"","tool_input":{"file_path":$file,"content":"x"}}' \
+  (cd "$TMPDIR2" && jq -n --arg file "$file" --arg sid "$OWNER_SID2" \
+    '{"tool_name":"Write","session_id":$sid,"tool_input":{"file_path":$file,"content":"x"}}' \
     | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
 }
 run_bash2() {
   local cmd="$1"
-  (cd "$TMPDIR2" && jq -n --arg cmd "$cmd" \
-    '{"tool_name":"Bash","session_id":"","tool_input":{"command":$cmd}}' \
+  (cd "$TMPDIR2" && jq -n --arg cmd "$cmd" --arg sid "$OWNER_SID2" \
+    '{"tool_name":"Bash","session_id":$sid,"tool_input":{"command":$cmd}}' \
     | bash "$HOOKS_DIR/bash-gate.sh" 2>/dev/null) || true
 }
 run_stop2() {
-  (cd "$TMPDIR2" && jq -n '{"session_id":""}' \
+  (cd "$TMPDIR2" && jq -n --arg sid "$OWNER_SID2" '{"session_id":$sid}' \
     | bash "$HOOKS_DIR/completion-gate.sh" 2>/dev/null) || true
 }
 

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -31,8 +31,9 @@ EOF
 
 TASK_DIR="$TMPDIR/.ai-bouncer-tasks/2026-01-01/test-task"
 PHASE_DIR="$TASK_DIR/phase-1-test"
+OWNER_SID="pg-owner-sess"
 mkdir -p "$TASK_DIR" "$PHASE_DIR" "$TASK_DIR/verifications"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 cat > "$TASK_DIR/plan.md" <<'EOF'
 # Plan
 ## 목표
@@ -50,14 +51,14 @@ EOF
 
 run_gate() {
   local file="$1"
-  (cd "$TMPDIR" && echo "{\"tool_name\":\"Edit\",\"session_id\":\"\",\"tool_input\":{\"file_path\":\"$file\",\"old_string\":\"x\",\"new_string\":\"y\"}}" | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
+  (cd "$TMPDIR" && echo "{\"tool_name\":\"Edit\",\"session_id\":\"$OWNER_SID\",\"tool_input\":{\"file_path\":\"$file\",\"old_string\":\"x\",\"new_string\":\"y\"}}" | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
 }
 
 run_gate_state() {
   local new_content="$1"
   local encoded
   encoded=$(echo "$new_content" | jq -Rs .)
-  (cd "$TMPDIR" && echo "{\"tool_name\":\"Write\",\"session_id\":\"\",\"tool_input\":{\"file_path\":\"$TASK_DIR/state.json\",\"content\":$encoded}}" \
+  (cd "$TMPDIR" && echo "{\"tool_name\":\"Write\",\"session_id\":\"$OWNER_SID\",\"tool_input\":{\"file_path\":\"$TASK_DIR/state.json\",\"content\":$encoded}}" \
     | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
 }
 
@@ -65,7 +66,7 @@ run_gate_write() {
   local file="$1" content="$2"
   local encoded
   encoded=$(echo "$content" | jq -Rs .)
-  (cd "$TMPDIR" && echo "{\"tool_name\":\"Write\",\"session_id\":\"\",\"tool_input\":{\"file_path\":\"$file\",\"content\":$encoded}}" \
+  (cd "$TMPDIR" && echo "{\"tool_name\":\"Write\",\"session_id\":\"$OWNER_SID\",\"tool_input\":{\"file_path\":\"$file\",\"content\":$encoded}}" \
     | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
 }
 
@@ -461,25 +462,26 @@ EOF
 rm -f "$TASK_DIR/.active"
 write_state "$BASE_STATE"
 check "TC-41: .active 없음 → allow" "$(run_gate "$DUMMY")" "allow"
-touch "$TASK_DIR/.active"
+echo "$OWNER_SID" > "$TASK_DIR/.active"
 
 # ── nested sub-project: git toplevel ≠ 작업 디렉토리 ──
 # (sub-dir이 자체 git repo가 아니면 git rev-parse가 상위 repo를 반환 →
 #  .ai-bouncer-tasks/가 toplevel 바로 아래가 아니어도 task 파일로 인식해야 함)
 
 NESTED_TASK="$TMPDIR/subproj/.ai-bouncer-tasks/2026-01-01/nested-task"
+NESTED_SID="pg-nested-sess"
 mkdir -p "$NESTED_TASK"
-touch "$NESTED_TASK/.active"
+echo "$NESTED_SID" > "$NESTED_TASK/.active"
 NESTED_STATE='{"workflow_phase":"planning","plan_approved":false,"current_dev_phase":0,"current_step":0,"dev_phases":{},"task_dir":".ai-bouncer-tasks/2026-01-01/nested-task","active_file":".ai-bouncer-tasks/2026-01-01/nested-task/.active"}'
 echo "$NESTED_STATE" > "$NESTED_TASK/state.json"
 NESTED_ENC=$(echo "$NESTED_STATE" | jq -Rs .)
 
 # TC-42: nested sub-project의 .ai-bouncer-tasks/ 하위 state.json (planning) → allow
-NESTED_OUT=$(cd "$TMPDIR/subproj" && echo "{\"tool_name\":\"Write\",\"session_id\":\"\",\"tool_input\":{\"file_path\":\"$NESTED_TASK/state.json\",\"content\":$NESTED_ENC}}" | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
+NESTED_OUT=$(cd "$TMPDIR/subproj" && echo "{\"tool_name\":\"Write\",\"session_id\":\"$NESTED_SID\",\"tool_input\":{\"file_path\":\"$NESTED_TASK/state.json\",\"content\":$NESTED_ENC}}" | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
 check "TC-42: nested sub-project planning state.json write → allow" "$NESTED_OUT" "allow"
 
 # TC-43: nested sub-project의 .ai-bouncer-tasks/ 밖 일반 소스 파일 (planning) → block (정상 차단 유지)
-NESTED_SRC_OUT=$(cd "$TMPDIR/subproj" && echo "{\"tool_name\":\"Write\",\"session_id\":\"\",\"tool_input\":{\"file_path\":\"$TMPDIR/subproj/foo.sh\",\"content\":\"echo hi\"}}" | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
+NESTED_SRC_OUT=$(cd "$TMPDIR/subproj" && echo "{\"tool_name\":\"Write\",\"session_id\":\"$NESTED_SID\",\"tool_input\":{\"file_path\":\"$TMPDIR/subproj/foo.sh\",\"content\":\"echo hi\"}}" | bash "$HOOKS_DIR/plan-gate.sh" 2>/dev/null) || true
 check "TC-43: nested sub-project non-task source file → block" "$NESTED_SRC_OUT" "block"
 
 echo ""

--- a/tests/test-resolve-task-session-isolation.sh
+++ b/tests/test-resolve-task-session-isolation.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# test-resolve-task-session-isolation.sh — 빈/타-SESSION_ID cross-session hijack 방지 검증
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RT="$REPO/hooks/lib/resolve-task.sh"
+HOOKS="$REPO/hooks"
+PASS=0; FAIL=0
+ok(){ echo "✅ $1"; PASS=$((PASS+1)); }
+ng(){ echo "❌ $1"; FAIL=$((FAIL+1)); }
+
+TMP=$(mktemp -d)
+OWNER="ownerA-$$"
+TD="$TMP/.ai-bouncer-tasks/2026-06-01/task-X"; mkdir -p "$TD"
+printf '%s' "$OWNER" > "$TD/.active"
+cat > "$TD/state.json" <<'EOF'
+{"workflow_phase":"development","plan_approved":true,"current_dev_phase":1,"current_step":1,"dev_phases":{}}
+EOF
+trap 'rm -rf "$TMP"' EXIT
+
+resolve(){ SESSION_ID="$1" bash -c 'cd "'"$TMP"'"; source "'"$RT"'"; echo "MY=$IS_MY_TASK NAME=$TASK_NAME"'; }
+decision(){ echo "$1" | jq -r '.decision // "allow"' 2>/dev/null || echo allow; }
+
+# TC-1 (negative): 빈 SESSION_ID → owner 인정 안 함
+O1=$(resolve "")
+echo "$O1" | grep -q "MY=true" && ng "TC-1: 빈 세션이 owner로 인정됨(취약) ($O1)" || ok "TC-1: 빈 세션 owner 거부"
+echo "$O1" | grep -qE "NAME=$" && ok "TC-1: TASK_NAME 빈값" || ng "TC-1: TASK_NAME 비어있지 않음 ($O1)"
+
+# TC-2 (negative): 다른 session_id → owner 아님
+O2=$(resolve "other-$$")
+echo "$O2" | grep -q "MY=true" && ng "TC-2: 다른 세션이 owner로 인정됨 ($O2)" || ok "TC-2: 다른 세션 owner 거부"
+
+# TC-3 (regression): 자기 session_id → owner 정상
+O3=$(resolve "$OWNER")
+echo "$O3" | grep -q "MY=true" && ok "TC-3: 자기 세션 owner 인정" || ng "TC-3(회귀): 자기 세션 owner 거부됨 ($O3)"
+echo "$O3" | grep -q "NAME=task-X" && ok "TC-3: TASK_NAME=task-X" || ng "TC-3: TASK_NAME 틀림 ($O3)"
+
+# TC-4 (e2e): bash-gate 빈 세션 + 쓰기 → block
+BG1=$(cd "$TMP" && jq -n '{tool_name:"Bash",session_id:"",tool_input:{command:"echo hi > realfile.sh"}}' | bash "$HOOKS/bash-gate.sh" 2>/dev/null)
+[ "$(decision "$BG1")" = "block" ] && ok "TC-4: bash-gate 빈 세션 쓰기 차단" || ng "TC-4: 차단 안 됨 ($BG1)"
+
+# TC-5 (regression): bash-gate 유효 세션(미점유) + 쓰기 → allow (가드 미발동)
+BG2=$(cd "$TMP" && jq -n --arg sid "valid-$$" '{tool_name:"Bash",session_id:$sid,tool_input:{command:"echo hi > realfile.sh"}}' | bash "$HOOKS/bash-gate.sh" 2>/dev/null)
+[ "$(decision "$BG2")" = "block" ] && ng "TC-5(회귀): 유효 세션이 차단됨 ($BG2)" || ok "TC-5: 유효 세션 쓰기 통과"
+
+# TC-6 (e2e): plan-gate 빈 세션 + 非plan 파일 Write → block
+PG1=$(cd "$TMP" && jq -n --arg fp "$TMP/foo.sh" '{tool_name:"Write",session_id:"",tool_input:{file_path:$fp,content:"x"}}' | bash "$HOOKS/plan-gate.sh" 2>/dev/null)
+[ "$(decision "$PG1")" = "block" ] && ok "TC-6: plan-gate 빈 세션 차단" || ng "TC-6: 차단 안 됨 ($PG1)"
+
+# TC-7 (regression): plan-gate 빈 세션이라도 ~/.claude/plans/ 쓰기는 통과 (CHECK 0 우선)
+PG2=$(cd "$TMP" && jq -n --arg fp "$HOME/.claude/plans/x.md" '{tool_name:"Write",session_id:"",tool_input:{file_path:$fp,content:"x"}}' | bash "$HOOKS/plan-gate.sh" 2>/dev/null)
+[ "$(decision "$PG2")" = "block" ] && ng "TC-7(회귀): plan 파일이 차단됨 ($PG2)" || ok "TC-7: plan 파일 쓰기 통과"
+
+echo ""; echo "결과: PASS=$PASS FAIL=$FAIL"; [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## 문제

`hooks/lib/resolve-task.sh`의 `_resolve_from_base()`에 "SESSION_ID가 없으면 첫 번째 활성 태스크를 무조건 자기 것으로 인정"하는 하위호환 분기가 있었다. 빈 `SESSION_ID`로 hook이 호출되면(stdin JSON에 session_id 누락 / 외부 도구 직접 호출 / 환경변수 미설정) **다른 세션이 점유 중인 task를 `IS_MY_TASK=true`로 부여** → cross-session hijack. 다른 세션 task의 gate가 자기 것처럼 작동하고 state.json 변경·commit 권한이 의도 외로 부여될 수 있었다.

## 수정

- **Fix 1 (핵심)** `resolve-task.sh`: 빈-SESSION_ID 분기를 `continue`로 교체 → 빈 SESSION_ID는 어떤 `.active`도 owner로 인정 안 함 (`TASK_NAME` 빈값, `IS_MY_TASK=false`).
- **Fix 2** 사용법 주석 갱신 (호출자 SESSION_ID 설정 의무 명시).
- **Fix 3 (defense-in-depth)** entry hook 가드:
  - `bash-gate.sh` / `plan-gate.sh`: `source resolve-task.sh` 직전, 빈 SESSION_ID면 `{decision:"block"}` (read-only·plan 파일은 영향 없음).
  - `completion-gate.sh`: Stop hook이므로 `exit 2`(세션 wedge) 대신 `exit 0` 통과.

> 스펙의 `exit 2` 대신 JSON `{decision:block}` 사용 — 두 gate의 기존 차단(~30곳) 컨벤션과 일치하고 테스트 하니스로 검증 가능. completion-gate는 Stop hook 안전성 때문에 exit 0.

## 테스트 (red → green)

- 신규 `tests/test-resolve-task-session-isolation.sh` (9 TC): 빈/타/자기 세션 owner 판정 + bash-gate/plan-gate 빈-세션 block/allow.
- **재현(red)**: 수정 전 코드에서 TC-1 실패 — `빈 세션이 owner로 인정됨 (MY=true NAME=task-X)`.
- **수정 확인(green)**: 수정 후 9 TC 전부 통과.
- 기존 gate/e2e 테스트(bash-gate/plan-gate/completion-gate/e2e-workflow)는 빈-세션 shortcut 의존을 제거하고 `.active` owner 세션 매칭으로 갱신 — 전부 baseline 동일(43/43/41/90, 회귀 0).
- `test-phase-layers.sh` 1건 실패는 baseline에서도 동일한 사전 존재 실패(이번 변경과 무관).

## 호환성

빈 SESSION_ID로 hook을 직접 호출하던 외부 도구는 명시적으로 SESSION_ID를 설정해야 함. 정상 Claude Code 세션은 항상 session_id를 전달하므로 영향 없음.